### PR TITLE
Add documentation mechanism

### DIFF
--- a/piws/docgen/__init__.py
+++ b/piws/docgen/__init__.py
@@ -1,0 +1,8 @@
+#! /usr/bin/env python
+##########################################################################
+# NSAp - Copyright (C) CEA, 2013
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################

--- a/piws/docgen/rst2html.py
+++ b/piws/docgen/rst2html.py
@@ -1,0 +1,89 @@
+#! /usr/bin/env python
+##########################################################################
+# NSAp - Copyright (C) CEA, 2013
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+# System import
+import os
+import re
+
+# Docutils import
+from docutils.core import publish_parts
+
+
+def rst2html(rstfile, data_url):
+    """ Create a html documentation from a rst description.
+
+    Parameters
+    ----------
+    rstfile: str (mandatory)
+        the documentation rst description.
+    data_url: str (mandatory)
+        the server data url.
+
+    Returns
+    -------
+    doc: str
+        the corresponding html documentation.
+    """
+    with open(rstfile, "r") as openfile:
+        rststr = "".join(openfile.readlines())
+        doc = publish_parts(rststr, writer_name="html")["html_body"]
+    doc = set_data_url(data_url, doc)
+    return doc
+
+
+def create_html_doc(directory, data_url):
+    """ Create the html documentation from the rst files available in the
+    input directory.
+
+    The mapping between each file and each CW entity is performed based on the
+    file name and entity label.
+
+    Parameters
+    ----------
+    directory: str (mandatory)
+        the input documentation directory: where we are looking for rst files.
+    data_url: str (mandatory)
+        the server data url.
+
+    Returns
+    -------
+    docmap: dict
+        a mapping with the expected CW entity label as key, associated with the
+        html documentation.
+    """
+    docmap = dict((rstfile.split(".")[0], rst2html(os.path.join(directory, rstfile), data_url))
+                  for rstfile in os.listdir(directory)
+                  if rstfile.endswith(".rst"))
+    return docmap
+
+
+def set_data_url(data_url, doc):
+    """ Transform the image source.
+
+    Note that all the images or resources have to be placed in the cube data
+    folder.
+
+    Parameters
+    ----------
+    data_url: str (mandatory)
+        the server data url.
+    doc: str
+        an html documentation.
+
+    Returns
+    -------
+    doc: str
+        the formatted html documentation.
+    """
+    matches = re.findall("<img.*/>", doc)
+    for imgtag in matches:
+        index = imgtag.index("src=") + 6
+        newimgtag = imgtag[:index] + data_url + imgtag[index:]
+        doc.replace(imgtag, newimgtag)
+    return doc

--- a/piws/hooks.py
+++ b/piws/hooks.py
@@ -7,3 +7,33 @@
 # for details.
 ##########################################################################
 
+# CW import
+from cubicweb.server import hook
+
+# PIWS import
+from cubes.piws.docgen.rst2html import create_html_doc
+
+
+class CreateDocumentation(hook.Hook):
+    """ On startup create the documentation.
+    """
+    __regid__ = "piws.create_documentation"
+    events = ("server_startup", )
+
+    def __call__(self):
+        """ The documantation is stored in repo.vreg.docmap and thus will
+        be accessible in any CW pages.
+        The docmap is a dictionary with the input rst documentation file
+        basenames as keys. The values contain the corresponding html codes.
+        """
+        # Get the data url
+        with self.repo.internal_cnx() as cnx:
+            data_url = cnx.base_url() + "/data/"
+
+        # Get the documentation
+        doc_folder = self.repo.vreg.config["documentation_folder"]
+        if doc_folder:
+            self.repo.vreg.docmap = create_html_doc(doc_folder, data_url)
+        else:
+            self.repo.vreg.docmap = {}
+

--- a/piws/site_cubicweb.py
+++ b/piws/site_cubicweb.py
@@ -9,11 +9,19 @@
 
 
 options = (
-    ("questionnaire_map",
-      {"type": "string",
-      "default": "",
-      "help": "the file containing the questionnaire questions labels.",
-      "group": "piws", "level": 0,
-      }),
+    ("questionnaire_map", {
+        "type": "string",
+        "default": "",
+        "help": "the file containing the questionnaire questions labels.",
+        "group": "piws",
+        "level": 0,
+    }),
+    ("documentation_folder", {
+        "type": "string",
+        "default": "",
+        "help": "the folder containing the documentation of the project.",
+        "group": "piws",
+        "level": 1,
+    })
 )
 

--- a/piws/views/documentation_views.py
+++ b/piws/views/documentation_views.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+##########################################################################
+# NSAp - Copyright (C) CEA, 2013
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+# Cubicweb import
+from cubicweb.view import View
+from cubicweb.web.views.baseviews import NullView
+
+
+class DisplayDocumentation(NullView):
+    """ Create a view to display the documentation.
+    """
+    __regid__ = "piws-documentation"
+    templatable = False
+    div_id = "piws-documentation"
+
+    def __init__(self, *args, **kwargs):
+        """ Initialize the DisplayDocumentation class.
+        """
+        super(DisplayDocumentation, self).__init__(*args, **kwargs)
+
+    def call(self, tooltip=None, **kwargs):
+        """
+        """
+        # Get the parameters
+        tooltip = tooltip or self._cw.form.get("tooltip", "")
+
+        # Display documentation
+        self.w(u"<!DOCTYPE html>")
+        self.w(u"<html xmlns:cubicweb='http://www.cubicweb.org' lang='en'>")
+        self.w(u"<head>")
+        self.w(u"<meta http-equiv='content-type' content='text/html; charset=UTF-8'/>")
+        self.w(u"<meta http-equiv='X-UA-Compatible' content='IE=8' />")
+        self.w(unicode(tooltip))
+
+
+###############################################################################
+# Update CW registery
+###############################################################################
+
+def registration_callback(vreg):
+    vreg.register(DisplayDocumentation)

--- a/piws/views/secondary.py
+++ b/piws/views/secondary.py
@@ -46,6 +46,9 @@ class NSScanOutOfContextView(EntityView):
                 __message=(u"Found '{0}' image(s) that can be "
                             "displayed.".format(limagefiles)))
 
+        # Get the associated documentation if available
+        tooltip = self._cw.vreg.docmap.get(entity.label, None)
+
         # Get the subject/study related entities
         subject = entity.subject[0]
         study = entity.study[0]
@@ -66,14 +69,27 @@ class NSScanOutOfContextView(EntityView):
         # > third element: the see more button
         self.w(u'<button class="btn btn-danger" type="button" '
                 'style="margin-top:8px" data-toggle="collapse" '
-                'data-target="#info-%s">' % row)
+                'data-target="#info-{0}">'.format(row))
         self.w(u'See more')
         self.w(u'</button>')
         # > fourth element: the show button
         if limagefiles > 0:
-            self.w(u'<a href="{0}" class="btn btn-success" type="button" '
+            self.w(u'<a href="{0}" target=_blank class="btn btn-success" type="button" '
                     'style="margin-top:8px">'.format(href))
-            self.w(u'Show')
+            self.w(u'Show &#9735')
+            self.w(u'</a>')
+        # > fifth element: the doc button
+        if tooltip is not None:
+            tiphref = self._cw.build_url("view", vid="piws-documentation",
+                                         tooltip=tooltip, _notemplate=True)
+            self.w(u'<button href="{0}" class="btn btn-warning" type="button" '
+                    'style="margin-top:8px" data-toggle="collapse" '
+                    'data-target="#doc-{0}">'.format(row))
+            self.w(u'Doc')
+            self.w(u'</button>')
+            self.w(u'<a href="{0}" target=_blank class="btn btn-warning" type="button" '
+                    'style="margin-top:8px">'.format(tiphref))
+            self.w(u'&#9735')
             self.w(u'</a>')
 
         # Close row item
@@ -84,7 +100,7 @@ class NSScanOutOfContextView(EntityView):
 
         # Create a div that will be show or hide when the see more button is
         # clicked
-        self.w(u'<div id="info-%s" class="collapse">' % row)
+        self.w(u'<div id="info-{0}" class="collapse">'.format(row))
         self.w(u'<dl class="dl-horizontal">')
         # > image shape
         self.w(u'<dt>Image Shape (x)</dt><dd>{0}</dd>'.format(
@@ -114,6 +130,12 @@ class NSScanOutOfContextView(EntityView):
             subject.view("incontext")))
         self.w(u'<dt>Ralated study</dt><dd>{0}</dd>'.format(
             study.view("incontext")))
+        self.w(u'</div>')
+
+        # Create a div that will be show or hide when the doc button is
+        # clicked
+        self.w(u'<div id="doc-{0}" class="collapse">'.format(row))
+        self.w(unicode(tooltip))
         self.w(u'</div>')
 
         # Close list item

--- a/piws/views/table_views.py
+++ b/piws/views/table_views.py
@@ -302,7 +302,7 @@ class JhugetableView(View):
         html += "var question_text = {0};".format(json.dumps(tooltips))
         html += "$('thead th').each(function(index, value){"
         html += "var sTitle = question_text[index];"
-        html += "this.setAttribute( 'title', sTitle );"
+        html += "this.setAttribute('title', sTitle);"
         html += "} );"
         html += "$( table.fnGetNodes() ).tooltip( {"
         html += "'delay': 0,"
@@ -493,9 +493,13 @@ class JtableView(View):
             # >> add this column to the table definition parameters
             label_list.append(label_cleaner(label_text[0]))
             if label_text[0] in qmap:
+                tiphref = self._cw.build_url(
+                    "view", vid="piws-documentation", tooltip=label_text[0],
+                    _notemplate=True)
                 headers.append(
-                    {"sTitle": "<span class='fake-link'> {0} "
-                     "</span>".format(label_text[0])})
+                    {"sTitle": "<a href='{0}' target=_blank>"
+                     "<span class='fake-link'>{1}"
+                     "</span></a>".format(tiphref, label_text[0])})
             else:
                 headers.append({"sTitle": label_text[0]})
 
@@ -651,7 +655,7 @@ class JtableView(View):
         html += "var question_text = {0};".format(json.dumps(tooltips))
         html += "$('thead th').each(function(index, value){"
         html += "var sTitle = question_text[index];"
-        html += "this.setAttribute( 'title', sTitle );"
+        html += "this.setAttribute('title', sTitle);"
         html += "} );"
         html += "$( table.fnGetNodes() ).tooltip( {"
         html += "'delay': 0,"


### PR DESCRIPTION
1) Standard strategy:

Define where is the rst documentation: -- documentation_folder cube parameter

All the documentation are stored at the server startup in self._cw.vreg.docmap.

Create a reference to the documentation html page: -- self._cw.build_url("view", vid="piws-documentation", tooltip=self._cw.vreg.docmap["my_doc"], _notemplate=True)

Or include the documentation in the page
-- self.w(self._cw.vreg.docmap["my_doc"])

Note: all the images must be in the cube data folder and a relative path must be specified in the rst documentation.

2) Questionnaires:

Define where is the file containing the questionnaire questions labels: -- questionnaire_map cube parameter

Documented columns will appear in blue.

A tooltip appear when the mouse is over the question text, and a new page is open when the link is clicked.
